### PR TITLE
Add missing dependency 'dependency-db' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bluebird": "^3.4.6",
     "boom": "^4.2.0",
     "concurrently": "^3.1.0",
+    "dependency-db": "^1.0.0",
     "dotenv": "^2.0.0",
     "good": "^7.0.2",
     "good-console": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "dependency-land",
-    "version": "1.0.0",
-    "description": "Find the npm modules that depend on a specific module and semver range.",
-    "main": "server.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "server": "node server.js",
-        "updater": "node db/updater.js",
-        "client": "node start-client.js",
-        "client-install": "npm install --prefix client/",
-        "client-build": "npm run build --prefix client/",
-        "postinstall": "npm run client-install && npm run client-build",
-        "start": "concurrently \"npm run server\" \"npm run client\"",
-        "prod-start": "concurrently \"npm run server\" \"npm run updater\"",
-        "track": "node track-release.js"
-    },
-    "private": true,
-    "author": "Vanja Cosic (https://twitter.com/vanjacosic)",
-    "license": "MIT",
-    "dependencies": {
-        "bluebird": "^3.4.6",
-        "boom": "^4.2.0",
-        "concurrently": "^3.1.0",
-        "dotenv": "^2.0.0",
-        "good": "^7.0.2",
-        "good-console": "^6.3.1",
-        "good-squeeze": "^5.0.1",
-        "hapi": "^15.2.0",
-        "inert": "^4.0.2",
-        "joi": "^10.0.1",
-        "level-party": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "npm-dependency-db": "^1.6.1",
-        "opbeat": "^4.1.0",
-        "semver": "^5.3.0",
-        "validate-npm-package-name": "^2.2.2"
-    },
-    "devDependencies": {},
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/opbeat/dependency-land.git"
-    },
-    "bugs": {
-        "url": "https://github.com/opbeat/dependency-land/issues"
-    },
-    "homepage": "https://github.com/opbeat/dependency-land#readme"
+  "name": "dependency-land",
+  "version": "1.0.0",
+  "description": "Find the npm modules that depend on a specific module and semver range.",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "server": "node server.js",
+    "updater": "node db/updater.js",
+    "client": "node start-client.js",
+    "client-install": "npm install --prefix client/",
+    "client-build": "npm run build --prefix client/",
+    "postinstall": "npm run client-install && npm run client-build",
+    "start": "concurrently \"npm run server\" \"npm run client\"",
+    "prod-start": "concurrently \"npm run server\" \"npm run updater\"",
+    "track": "node track-release.js"
+  },
+  "private": true,
+  "author": "Vanja Cosic (https://twitter.com/vanjacosic)",
+  "license": "MIT",
+  "dependencies": {
+    "bluebird": "^3.4.6",
+    "boom": "^4.2.0",
+    "concurrently": "^3.1.0",
+    "dotenv": "^2.0.0",
+    "good": "^7.0.2",
+    "good-console": "^6.3.1",
+    "good-squeeze": "^5.0.1",
+    "hapi": "^15.2.0",
+    "inert": "^4.0.2",
+    "joi": "^10.0.1",
+    "level-party": "^3.0.4",
+    "mkdirp": "^0.5.1",
+    "npm-dependency-db": "^1.6.1",
+    "opbeat": "^4.1.0",
+    "semver": "^5.3.0",
+    "validate-npm-package-name": "^2.2.2"
+  },
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opbeat/dependency-land.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opbeat/dependency-land/issues"
+  },
+  "homepage": "https://github.com/opbeat/dependency-land#readme"
 }


### PR DESCRIPTION
Besides adding the missing dependency (77f9748), this PR also reformats the `package.json` file so it's "compatible" with the `npm` cli. This way each change to the file doesn't result in all lines being changed.

Think of `package.json` as a file that can be overwritten by the system at any time without warning. So one should normally not edit it manually, but instead use the `npm` cli.