### PR TITLE
Fix clear icon overlapping input text

### DIFF
--- a/client/src/components/PackageSearch/index.js
+++ b/client/src/components/PackageSearch/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Client from './Client';
 import ReactDOM from 'react-dom';
+import classnames from 'classnames';
 
 import SearchInfo from '../SearchInfo';
 
@@ -170,6 +171,14 @@ const PackageSearch = React.createClass({
 
     render () {
         const { searchValueForName, searchValueForRange } = this.state
+        const showClearIconForName = searchValueForName.length > 0
+        const showClearIconForRange = searchValueForRange.length > 0
+        const searchInputNameClass = classnames('ui', 'labeled', 'input', 'SearchInputName', {
+          'icon': showClearIconForName
+        });
+        const searchInputRangeClass = classnames('ui', 'labeled', 'input', 'SearchInputRange', {
+          'icon': showClearIconForRange
+        });
 
         return (
             <div className='PackageSearch'>
@@ -179,7 +188,7 @@ const PackageSearch = React.createClass({
                     <form onSubmit={this.onSubmit} className="ui stackable grid">
                         <div className="eight wide column">
 
-                            <div className="ui labeled input SearchInputName">
+                            <div className={searchInputNameClass}>
                                 <div className="ui label">
                                 package
                                 </div>
@@ -193,7 +202,7 @@ const PackageSearch = React.createClass({
                                     autoFocus
                                     />
                                 {
-                                    searchValueForName.length > 0 ? (
+                                    showClearIconForName ? (
                                         <i
                                             className='remove icon link'
                                             onClick={ this.handleCancelForName }
@@ -204,7 +213,7 @@ const PackageSearch = React.createClass({
                         </div>
 
                         <div className="eight wide column">
-                            <div className="ui labeled input SearchInputRange">
+                            <div className={searchInputRangeClass}>
 
                                 <div className="ui label">
                                 range
@@ -218,7 +227,7 @@ const PackageSearch = React.createClass({
                                     ref="rangeInput"
                                     />
                                 {
-                                    searchValueForRange.length > 0 ? (
+                                    showClearIconForRange ? (
                                         <i
                                             className='remove icon link'
                                             onClick={ this.handleCancelForRange }


### PR DESCRIPTION
Before:

![Before](https://cloud.githubusercontent.com/assets/652793/22664552/7cc3622c-ecb1-11e6-855c-1fed4e2b7b4d.png)

After:

![after](https://cloud.githubusercontent.com/assets/652793/22664562/86198248-ecb1-11e6-83bf-2d86b3e15405.png)

This also changes the appearance slightly. For example, the clear icon is grayed out when the input field is not in focus.