### PR TITLE
Use newest dependency-db

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -18,10 +18,18 @@ const dbPath = path.join(pathPrefix, '.npm-dependency-db')
 
 mkdirp.sync(dbPath)
 
-exports.level = () => {
-  const db = level(dbPath)
+exports.hypercore = () => {
+  const db = level(path.join(dbPath, 'hypercore'))
 
-  utils.log(`Database loaded from: ${db.location}`)
+  utils.log(`hypercore database loaded from: ${db.location}`)
+
+  return db
+}
+
+exports.depdb = () => {
+  const db = level(path.join(dbPath, 'dependency-db'))
+
+  utils.log(`dependency-db database loaded from: ${db.location}`)
 
   return db
 }

--- a/db/db.js
+++ b/db/db.js
@@ -18,7 +18,7 @@ const dbPath = path.join(pathPrefix, '.npm-dependency-db')
 
 mkdirp.sync(dbPath)
 
-module.exports.level = () => {
+exports.level = () => {
   const db = level(dbPath)
 
   utils.log(`Database loaded from: ${db.location}`)

--- a/db/query.js
+++ b/db/query.js
@@ -4,7 +4,7 @@ const DepDb = require('dependency-db')
 const sub = require('subleveldown')
 
 const db = require('./db.js')
-const depDb = new DepDb(sub(db.level(), 'depdb'))
+const depDb = new DepDb(sub(db.depdb(), 'depdb'))
 
 module.exports = (name, range) => {
   return new Promise((resolve, reject) => {

--- a/db/updater.js
+++ b/db/updater.js
@@ -4,7 +4,8 @@ global.utils = require('../utils.js')
 const DbUpdater = require('npm-dependency-db/updater')
 const db = require('./db.js')
 
-const updater = new DbUpdater(db.level(), {
+const updater = new DbUpdater(db.depdb(), {
+  npmDb: db.hypercore(),
   live: true
 })
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bluebird": "^3.4.6",
     "boom": "^4.2.0",
     "concurrently": "^3.1.0",
-    "dependency-db": "^3.0.0",
+    "dependency-db": "^4.0.0",
     "dotenv": "^4.0.0",
     "good": "^7.0.2",
     "good-console": "^6.2.0",
@@ -32,7 +32,7 @@
     "joi": "^10.0.1",
     "level-party": "^3.0.4",
     "mkdirp": "^0.5.1",
-    "npm-dependency-db": "^3.0.0",
+    "npm-dependency-db": "^4.0.0",
     "opbeat": "^4.1.0",
     "semver": "^5.3.0",
     "subleveldown": "^2.1.0"

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,4 @@
-module.exports.init = function (server) {
+exports.init = function (server) {
   // Route for api
   require('./api.js')(server)
 


### PR DESCRIPTION
This fixes [a bug](https://twitter.com/mikeal/status/829396910226055170) that ment that queries for packages with dependants whos name contained an exclamation mark (`!`) didn't work.

This PR also uses the oppotunity to separate the hypercore backed npm-change-feed and the dependency-db databases into two separate levelDB folders. That way, re-computing the dependency-db index will not require a complete re-download of all the npm data next time we change the dependency-db database format.

/cc @mikeal