### PR TITLE
Simplify returned result object

### DIFF
--- a/client/src/components/PackageSearch/index.js
+++ b/client/src/components/PackageSearch/index.js
@@ -116,6 +116,8 @@ const PackageSearch = React.createClass({
       isLoading: true
     })
 
+    let _name = name
+
     Client.search(name, range, dev, (result) => {
       if (result.error) {
         let errorState = Object.assign({}, resetState, {
@@ -126,7 +128,7 @@ const PackageSearch = React.createClass({
       } else {
         this.setState({
           results: result.results,
-          queryName: result.query.name,
+          queryName: _name,
           isLoading: false
         })
       }

--- a/db/query.js
+++ b/db/query.js
@@ -48,10 +48,7 @@ module.exports = (name, range, opts) => {
 
   function flushHead () {
     headFlushed = true
-    json.write(`{
-      "query": {"name":"${name}","range":"${range}"},
-      "results": [
-    `)
+    json.write('{"results":[')
   }
 
   function flushTail () {


### PR DESCRIPTION
~~*Depends on #14*~~

If we really want this info in the client, we technically already have it, so there's no need to send it back from the server.