### PR TITLE
Handle back pressure when returning query result

### DIFF
--- a/client/src/components/PackageSearch/index.js
+++ b/client/src/components/PackageSearch/index.js
@@ -116,6 +116,8 @@ const PackageSearch = React.createClass({
       isLoading: true
     })
 
+    let _name = name
+
     Client.search(name, range, dev, (result) => {
       if (result.error) {
         let errorState = Object.assign({}, resetState, {
@@ -126,7 +128,7 @@ const PackageSearch = React.createClass({
       } else {
         this.setState({
           results: result.results,
-          queryName: result.query.name,
+          queryName: _name,
           isLoading: false
         })
       }

--- a/client/src/components/PackageSearch/index.js
+++ b/client/src/components/PackageSearch/index.js
@@ -127,7 +127,7 @@ const PackageSearch = React.createClass({
         this.setState(errorState)
       } else {
         this.setState({
-          results: result.results,
+          results: result,
           queryName: _name,
           isLoading: false
         })

--- a/db/query.js
+++ b/db/query.js
@@ -48,10 +48,7 @@ module.exports = (name, range, opts) => {
 
   function flushHead () {
     headFlushed = true
-    json.write(`{
-      "query": {"name":"${name}","range":"${range}"},
-      "results": [
-    `)
+    json.write('{"results":[')
   }
 
   function flushTail () {

--- a/db/query.js
+++ b/db/query.js
@@ -1,7 +1,8 @@
 const DepDb = require('dependency-db')
 const sub = require('subleveldown')
-const PassThrough = require('readable-stream').PassThrough
-const opbeat = require('opbeat')
+const through2 = require('through2')
+const JSONStream = require('JSONStream')
+const pumpify = require('pumpify')
 
 const db = require('./db.js')
 const depDb = new DepDb(sub(db.depdb(), 'depdb'))
@@ -10,67 +11,20 @@ module.exports = (name, range, opts) => {
   if (!opts) opts = {}
   range = range || '*'
 
-  let results = depDb.query(name, range, opts)
-  let json = new PassThrough()
   let total = 0
-  let headFlushed = false
-
-  if (!name) {
-    flushError(new Error('missing required name'))
-    return json
-  }
-
-  console.log('Looking up %s %s dependants...', name, range)
-
-  results.once('error', flushError)
-  results.on('data', onData)
-  results.on('end', onEnd)
-
-  return json
-
-  function onData (pkg) {
-    if (!headFlushed) flushHead()
-
-    let prefix = total++ > 0 ? ',' : ''
-
-    json.write(prefix + JSON.stringify({
+  let results = depDb.query(name, range, opts)
+  let parser = through2.obj(function (pkg, enc, cb) {
+    total++
+    cb(null, {
       name: pkg.name,
       version: pkg.version,
       range: opts.devDependencies ? pkg.devDependencies[name] : pkg.dependencies[name]
-    }) + '\n')
-  }
+    })
+  })
 
-  function onEnd () {
-    if (!headFlushed) flushHead()
-    flushTail()
+  console.log('Looking up %s %s dependants...', name, range)
+
+  return pumpify(results, parser, JSONStream.stringify()).on('end', function () {
     console.log('results for %s@%s: %d', name, range, total)
-  }
-
-  function flushHead () {
-    headFlushed = true
-    json.write('{"results":[')
-  }
-
-  function flushTail () {
-    json.end(']}')
-  }
-
-  function flushError (err) {
-    results.removeListener('data', onData)
-    results.removeListener('end', onEnd)
-
-    opbeat.captureError(err)
-
-    if (headFlushed) {
-      json.end(`],
-        "error": true,
-        "message": "${err.message}"
-      }`)
-    } else {
-      json.end(`{
-        "error": true,
-        "message": "${err.message}"
-      }`)
-    }
-  }
+  })
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "Vanja Cosic (https://twitter.com/vanjacosic)",
   "license": "MIT",
   "dependencies": {
+    "JSONStream": "^1.3.0",
     "bluebird": "^3.4.6",
     "boom": "^4.2.0",
     "concurrently": "^3.1.0",
@@ -35,9 +36,11 @@
     "mkdirp": "^0.5.1",
     "npm-dependency-db": "^5.0.0",
     "opbeat": "^4.1.0",
+    "pumpify": "^1.3.5",
     "readable-stream": "^2.2.2",
     "semver": "^5.3.0",
-    "subleveldown": "^2.1.0"
+    "subleveldown": "^2.1.0",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "standard": "^8.6.0"


### PR DESCRIPTION
*Depends on #15*

This results in a lot lower memory usage!

This PR changes the JSON returned when querying to an array of results (instead of an object with a nested `results` property).

This makes handling back pressure a lot simpler. It would be possible to do this while returning an object, but I don't this it's necessary.

The only thing we'll miss from this is not returning an error object if the query fails (since we now return an array). But this is such a rare edge case that most likely will only happen if there's a bug in the database. So it's not worth sending a nicely formatted error message in that case I think. We could update the client to not show the JSON parse error that will happen in that case though.