### PR TITLE
search results infinite scroll

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^15.4.1",
     "react-router": "^3.0.2",
     "react-scripts": "0.7.0",
+    "react-waypoint": "^5.1.0",
     "recursive-readdir": "2.1.0",
     "rimraf": "2.5.4",
     "strip-ansi": "3.0.1",

--- a/client/src/components/PackageSearch/Client.js
+++ b/client/src/components/PackageSearch/Client.js
@@ -1,20 +1,38 @@
 import fetch from 'isomorphic-fetch'
 
 function search (query, range, dev, cb) {
-  query = encodeURIComponent(query)
-  range = encodeURIComponent(range)
+  return (limit = 50, gt) => {
+    const _query = encodeURIComponent(query)
+    const _range = encodeURIComponent(range)
 
-  return fetch(`/api/query/${query}${range ? '/' : ''}${range}${dev ? '?dev=1' : ''}`, {
-    accept: 'application/json'
-  }).then(checkStatus)
-    .then(parseJSON)
-    .then(cb)
-    .catch(function (err) {
-      cb({
-        error: true,
-        message: err.message
+    return fetch(withParamteres(`/api/query/${_query}${_range ? '/' : ''}${_range}`, [
+      { name: 'dev', value: 1, condition: dev },
+      { name: 'limit', value: limit },
+      { name: 'gt', value: gt }
+    ]), {
+      accept: 'application/json'
+    }).then(checkStatus)
+      .then(parseJSON)
+      .then(cb)
+      .catch(function (err) {
+        cb({
+          error: true,
+          message: err.message
+        })
       })
-    })
+  }
+}
+
+function withParamteres (path, parameters) {
+  const condition = (val) => typeof val.condition === 'undefined'
+    ? typeof val.value !== 'undefined'
+      : val.condition
+
+  return parameters.reduce((acc, val) =>
+    condition(val)
+      ? `${acc}${(acc.indexOf('?') === -1) ? '?' : '&'}${val.name}=${val.value}`
+        : acc
+  , path)
 }
 
 function checkStatus (response) {

--- a/client/src/components/PackageSearch/index.js
+++ b/client/src/components/PackageSearch/index.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom'
 import classnames from 'classnames'
 
 import SearchInfo from '../SearchInfo'
+import SearchResults from '../SearchResults'
 
 import './style.css'
 
@@ -309,122 +310,5 @@ const PackageSearch = React.createClass({
     )
   }
 })
-
-function SearchResults (props) {
-  const {
-    results,
-    searchValueForName,
-    searchValueForRange,
-    errorMessage
-  } = props
-
-  if (errorMessage.length > 0) {
-    return (
-      <h2 className='ui center disabled aligned icon header'>
-        <i className='circular warning sign icon' />
-        Error:
-        <p>
-          <small>"{ errorMessage }"</small>
-        </p>
-      </h2>
-    )
-  }
-
-  if (results === null) {
-    return (
-      <Message>
-        Search for { searchValueForName || 'a package' }
-        { searchValueForRange ? ('@' + searchValueForRange) : '' }
-      </Message>
-    )
-  }
-
-  if (results.length === 0) {
-    return (
-      <Message>
-          No results found
-      </Message>
-    )
-  }
-
-  return (
-    <div>
-      {results.length > 0 ? <SearchResultsModules {...props} /> : null}
-    </div>
-  )
-}
-
-const Message = ({ children }) => (
-  <h2 className='ui center disabled aligned icon header'>
-    <i className='circular search icon' />
-    {children}
-  </h2>
-)
-
-function SearchResultsCount ({ results }) {
-  if (!results) {
-    return (
-      <p>
-        { ' '.replace(/ /g, '\u00a0') }
-      </p>
-    )
-  } else {
-    return (
-      <p>
-        Found <b>{results}</b> dependents:
-      </p>
-    )
-  }
-}
-
-class SearchResultsModules extends React.Component {
-  shouldComponentUpdate (nextProps) {
-    return (
-      nextProps.queryName !== this.props.queryName
-    )
-  }
-
-  render () {
-    const {
-      results,
-      queryName
-    } = this.props
-
-    return (
-      <div>
-        <SearchResultsCount
-          results={results.length}
-        />
-        <table className='ui selectable structured large table'>
-          <thead className='left'>
-            <tr>
-              <th className='six wide'>Dependent package name</th>
-              <th>Latest dependent version</th>
-              <th>Range for <i>{ queryName }</i></th>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              results.map((_package, idx) => (
-                <tr key={idx}>
-                  <td>
-                    <a
-                      href={'https://www.npmjs.com/package/' + _package.name}
-                      target='_blank'
-                    >
-                      {_package.name}
-                    </a>
-                  </td>
-                  <td className='left aligned'>{_package.version}</td>
-                  <td className='left aligned'>{_package.range}</td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
-      </div>
-    )
-  }
-}
 
 export default PackageSearch

--- a/client/src/components/PackageSearch/index.js
+++ b/client/src/components/PackageSearch/index.js
@@ -131,9 +131,7 @@ const PackageSearch = React.createClass({
 
     let _name = name
 
-    const res = (result) => this.state.results !== null
-      ? [...this.state.results, ...result]
-        : result
+    const res = (result) => [...(this.state.results||[]), ...result]
 
     const gt = (result) => result[result.length - 1] && result[result.length - 1].name
 

--- a/client/src/components/SearchResults/index.js
+++ b/client/src/components/SearchResults/index.js
@@ -61,7 +61,7 @@ function SearchResultsCount ({ results }) {
   } else {
     return (
       <p>
-        Found <b>{results}</b> dependents:
+        Found <b>{results}</b> dependents.
       </p>
     )
   }
@@ -70,7 +70,7 @@ function SearchResultsCount ({ results }) {
 class SearchResultsModules extends React.Component {
   shouldComponentUpdate (nextProps) {
     return (
-      nextProps.queryName !== this.props.queryName
+      nextProps.queryName !== this.props.queryName || this.props.results.length < nextProps.results.length
     )
   }
 
@@ -82,9 +82,6 @@ class SearchResultsModules extends React.Component {
 
     return (
       <div>
-        <SearchResultsCount
-          results={results.length}
-        />
         <table className='ui selectable structured large table'>
           <thead className='left'>
             <tr>
@@ -112,6 +109,9 @@ class SearchResultsModules extends React.Component {
             }
           </tbody>
         </table>
+        <SearchResultsCount
+          results={results.length}
+        />
       </div>
     )
   }

--- a/client/src/components/SearchResults/index.js
+++ b/client/src/components/SearchResults/index.js
@@ -1,0 +1,120 @@
+import React from 'react'
+
+function SearchResults (props) {
+  const {
+    results,
+    searchValueForName,
+    searchValueForRange,
+    errorMessage
+  } = props
+
+  if (errorMessage.length > 0) {
+    return (
+      <h2 className='ui center disabled aligned icon header'>
+        <i className='circular warning sign icon' />
+        Error:
+        <p>
+          <small>"{ errorMessage }"</small>
+        </p>
+      </h2>
+    )
+  }
+
+  if (results === null) {
+    return (
+      <Message>
+        Search for { searchValueForName || 'a package' }
+        { searchValueForRange ? ('@' + searchValueForRange) : '' }
+      </Message>
+    )
+  }
+
+  if (results.length === 0) {
+    return (
+      <Message>
+          No results found
+      </Message>
+    )
+  }
+
+  return (
+    <div>
+      {results.length > 0 ? <SearchResultsModules {...props} /> : null}
+    </div>
+  )
+}
+
+const Message = ({ children }) => (
+  <h2 className='ui center disabled aligned icon header'>
+    <i className='circular search icon' />
+    {children}
+  </h2>
+)
+
+function SearchResultsCount ({ results }) {
+  if (!results) {
+    return (
+      <p>
+        { ' '.replace(/ /g, '\u00a0') }
+      </p>
+    )
+  } else {
+    return (
+      <p>
+        Found <b>{results}</b> dependents:
+      </p>
+    )
+  }
+}
+
+class SearchResultsModules extends React.Component {
+  shouldComponentUpdate (nextProps) {
+    return (
+      nextProps.queryName !== this.props.queryName
+    )
+  }
+
+  render () {
+    const {
+      results,
+      queryName
+    } = this.props
+
+    return (
+      <div>
+        <SearchResultsCount
+          results={results.length}
+        />
+        <table className='ui selectable structured large table'>
+          <thead className='left'>
+            <tr>
+              <th className='six wide'>Dependent package name</th>
+              <th>Latest dependent version</th>
+              <th>Range for <i>{ queryName }</i></th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              results.map((_package, idx) => (
+                <tr key={idx}>
+                  <td>
+                    <a
+                      href={'https://www.npmjs.com/package/' + _package.name}
+                      target='_blank'
+                    >
+                      {_package.name}
+                    </a>
+                  </td>
+                  <td className='left aligned'>{_package.version}</td>
+                  <td className='left aligned'>{_package.range}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+export default SearchResults


### PR DESCRIPTION
#17 search results infinite scroll

* moved SearchResults into separate file
* added react-waypoint to detect scroll to the end of the results page
* added limit and gt parameters to Client
* added limit prop and default value to PackageSearch
* handle append of paging results instead of replacing in PackageSearch#runSearch
* clear paging state in PackageSearch#componentWillReceiveProps
* implement end of page callback
* added results length check in SearchResultsModules#shouldComponentUpdate
* moved results count after search results